### PR TITLE
Update imports and requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12.3] #, windows-latest]
+        os: [ubuntu-latest] #, macos-12.3] #, windows-latest]
         python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest] #, windows-latest]
+        os: [ubuntu-latest, macos-12.3] #, windows-latest]
         python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## neptune-fastai 1.1.0
+
+### Changes
+- Updated integration for compatibility with `neptune 1.X`
+- Removed `neptune` and `neptune-client` from base requirements - installation is checked at runtime
+- Functions outside the callback accept `Handler` as well
+
 ## neptune-fastai 1.0.0
 
   ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ python = "^3.7"
 importlib-metadata = { version = "*", python = "<3.8" }
 
 # Base requirements
-neptune-client = ">=1.0.0"
 fastai = ">=2.4"
 
 # dev
@@ -24,6 +23,7 @@ pytest = { version = ">=5.0", optional = true }
 pytest-tap = { version = "3.2", optional = true }
 pytest-cov = { version = "2.10.1", optional = true }
 pytest-xdist = { version = "2.2.0", optional = true }
+neptune = { version = ">=1.0.0", optional = true }
 
 [tool.poetry.extras]
 dev = [
@@ -32,6 +32,7 @@ dev = [
     "pytest-cov",
     "pytest-tap",
     "pytest-xdist",
+    "neptune",
 ]
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,13 @@ style = "semver"
 pattern = "default-unprefixed"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 # Python lack of functionalities from future versions
 importlib-metadata = { version = "*", python = "<3.8" }
 
 # Base requirements
-neptune-client = ">=0.16.17"
+neptune-client = ">=1.0.0"
 fastai = ">=2.4"
 
 # dev

--- a/src/neptune_fastai/impl/__init__.py
+++ b/src/neptune_fastai/impl/__init__.py
@@ -353,9 +353,9 @@ def _log_or_assign_metric(run: Union[Run, Handler], number_of_epochs: int, metri
 
 
 def retrieve_fit_index(run: Union[Run, Handler], path: str) -> int:
-    if isinstance(run, Run):
-        root = run
-    elif isinstance(run, Handler):
+    root = run
+
+    if isinstance(run, Handler):
         root = run.get_root_object()
 
     return len(root.get_attribute(path) or [])

--- a/src/neptune_fastai/impl/__init__.py
+++ b/src/neptune_fastai/impl/__init__.py
@@ -38,28 +38,19 @@ from fastai.torch_core import (
     default_device,
     trainable_params,
 )
-
-try:
-    # neptune-client=0.9.0+ package structure
-    import neptune.new as neptune
-    from neptune.new import Run
-    from neptune.new.handler import Handler
-    from neptune.new.integrations.utils import (
-        expect_not_an_experiment,
-        verify_type,
-    )
-    from neptune.new.types import File
-    from neptune.new.utils import stringify_unsupported
-except ImportError:
-    # neptune-client>=1.0.0 package structure
-    import neptune  # isort:skip
-    from neptune.integrations.utils import expect_not_an_experiment, verify_type
-    from neptune.handler import Handler
-    from neptune import Run
-    from neptune.types import File  # isort:skip
-    from neptune.utils import stringify_unsupported
+from neptune import Run
+from neptune.handler import Handler
+from neptune.integrations.utils import (
+    expect_not_an_experiment,
+    verify_type,
+)
+from neptune.utils import stringify_unsupported
 
 from neptune_fastai.impl.version import __version__
+
+import neptune  # isort:skip
+from neptune.types import File  # isort:skip
+
 
 INTEGRATION_VERSION_KEY = "source_code/integrations/neptune-fastai"
 

--- a/src/neptune_fastai/impl/__init__.py
+++ b/src/neptune_fastai/impl/__init__.py
@@ -51,12 +51,12 @@ try:
     from neptune.types import File
     from neptune.utils import stringify_unsupported
 except ImportError:
+    from neptune.new import Run
     from neptune.new.handler import Handler
     from neptune.new.integrations.utils import (
         expect_not_an_experiment,
         verify_type,
     )
-    from neptune.new.metadata_containers import Run
     from neptune.new.types import File
     from neptune.new.utils import stringify_unsupported
 

--- a/src/neptune_fastai/impl/__init__.py
+++ b/src/neptune_fastai/impl/__init__.py
@@ -39,6 +39,8 @@ from fastai.torch_core import (
     trainable_params,
 )
 
+from neptune_fastai.impl.version import __version__
+
 try:
     from neptune import Run
     from neptune.handler import Handler
@@ -49,16 +51,14 @@ try:
     from neptune.types import File
     from neptune.utils import stringify_unsupported
 except ImportError:
-    from neptune.new.metadata_containers import Run
-    from neptune.new.types import File
     from neptune.new.handler import Handler
     from neptune.new.integrations.utils import (
         expect_not_an_experiment,
         verify_type,
     )
+    from neptune.new.metadata_containers import Run
+    from neptune.new.types import File
     from neptune.new.utils import stringify_unsupported
-
-from neptune_fastai.impl.version import __version__
 
 INTEGRATION_VERSION_KEY = "source_code/integrations/neptune-fastai"
 

--- a/src/neptune_fastai/impl/version.py
+++ b/src/neptune_fastai/impl/version.py
@@ -1,6 +1,7 @@
 __all__ = ["__version__"]
 
 import sys
+from importlib.util import find_spec
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import (
@@ -12,6 +13,14 @@ else:
         PackageNotFoundError,
         version,
     )
+
+if not (find_spec("neptune") or find_spec("neptune-client")):
+    msg = """
+            The Neptune client library was not found.
+            Install the neptune package with
+                `pip install neptune`
+            Need help? -> https://docs.neptune.ai/setup/installation/"""
+    raise PackageNotFoundError(msg)
 
 try:
     __version__ = version("neptune-fastai")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import neptune
 import pytest
 from fastai.basics import (
     URLs,
@@ -24,13 +25,6 @@ from fastai.tabular.all import (
     Normalize,
     TabularDataLoaders,
 )
-
-try:
-    # neptune-client=0.9.0 package structure
-    from neptune import new as neptune
-except ImportError:
-    # neptune-client=1.0.0 package structure
-    import neptune
 
 
 @pytest.fixture()

--- a/tests/neptune_fastai/test_e2e.py
+++ b/tests/neptune_fastai/test_e2e.py
@@ -52,7 +52,7 @@ def is_cat(x):
 
 
 class TestE2E:
-    def test_vision_classification(self):
+    def test_vision_classification_with_handler(self):
         # given (Subject)
         run = init_run(name="Integration fastai (vision classification)")["test"]
         root_obj = run.get_root_object()

--- a/tests/neptune_fastai/test_e2e.py
+++ b/tests/neptune_fastai/test_e2e.py
@@ -15,7 +15,6 @@
 #
 from itertools import islice
 
-import neptune.new as neptune
 from fastai.basics import (
     URLs,
     accuracy,
@@ -37,7 +36,13 @@ from fastai.vision.all import (
     get_image_files,
     squeezenet1_0,
 )
-from neptune.new.integrations.fastai import NeptuneCallback
+
+try:
+    from neptune import init_run
+    from neptune.integrations.fastai import NeptuneCallback
+except ImportError:
+    from neptune.new import init_run
+    from neptune.new.integrations.fastai import NeptuneCallback
 
 import neptune_fastai
 
@@ -49,7 +54,8 @@ def is_cat(x):
 class TestE2E:
     def test_vision_classification(self):
         # given (Subject)
-        run = neptune.init_run(name="Integration fastai (vision classification)")
+        run = init_run(name="Integration fastai (vision classification)")["test"]
+        root_obj = run.get_root_object()
 
         path = untar_data(URLs.PETS) / "images"
 
@@ -71,11 +77,11 @@ class TestE2E:
         )
 
         learn.fit(1)
-        run.sync()
+        root_obj.sync()
 
         # then
         # correct integration version is logged
-        logged_version = run["source_code/integrations/neptune-fastai"].fetch()
+        logged_version = root_obj["source_code/integrations/neptune-fastai"].fetch()
         assert logged_version == neptune_fastai.__version__
 
         # and
@@ -96,7 +102,7 @@ class TestE2E:
 
     def test_tabular_model(self):
         # given (Subject)
-        run = neptune.init_run(name="Integration fastai (tabular model)")
+        run = init_run(name="Integration fastai (tabular model)")
 
         path = untar_data(URLs.ADULT_SAMPLE)
 


### PR DESCRIPTION
## What's changing:
- neither `neptune` nor `neptune-client` is part of the requirements
- integration stays compatible with both major versions of the client
- in case neither `neptune` nor `neptune-client` is installed, an appropriate exception is raised with instructions for installation
- functions outside of the callback class also accept Handler now